### PR TITLE
Add deploy bash for Raspbery Pi

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+pip install -r requirements.txt --break-system-packages
+sudo pip install -r requirements.txt --break-system-packages
+sudo cp -r app.service /etc/systemd/system
+sudo systemctl daemon-reload
+sudo systemctl restart app
+echo "Complete."


### PR DESCRIPTION
As the title said. It could help you deploy client software on Raspberry Pi automatically!
  
Usage:
- Pull this repo 
- Use ``chmod a+x deploy.sh`` to give a permission
- Use ``sh deploy.sh`` on non-root user (like ``pi`` or ``mbernal``) of Raspberry Pi
- Wait until completed.
